### PR TITLE
Solve problem of git repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Circos is one of the most famous software for the visualization of genomic simil
 
 ### Installation
 1. Download the github packages using the following single command.  
-   ```git clone https://github.com/ponnhide/pyCircos/blob/master/pycircos.py```
+   ```git clone https://github.com/ponnhide/pyCircos```
 
 2. Install the necessary Python packages using the following commands.  
    ```pip install matplotlib```  


### PR DESCRIPTION
Hello,

This Command in **README** is not correct. you can see this error:
```
[max@base OpenSource]$ git clone https://github.com/ponnhide/pyCircos/blob/master/pycircos.py
Cloning into 'pycircos.py'...
fatal: repository 'https://github.com/ponnhide/pyCircos/blob/master/pycircos.py/' not found
```

But after apply change, works:

```
[max@base OpenSource]$ git clone https://github.com/ponnhide/pyCircos
Cloning into 'pyCircos'...
remote: Enumerating objects: 37, done.
remote: Counting objects: 100% (37/37), done.
remote: Compressing objects: 100% (31/31), done.
```

Thanks for reading my report issue.

Regards,