### PR TITLE
transcribed docstrings from readme to pycircos.py

### DIFF
--- a/pycircos/pycircos.py
+++ b/pycircos/pycircos.py
@@ -41,7 +41,66 @@ class Garc:
     def __getitem__(self, key):
         return self.__dict__[key] 
 
-    def __init__(self, arc_id=None, record=None, size=1000, interspace=3, raxis_range=(500, 550), facecolor=None, edgecolor="#303030", linewidth=0.75, label=None, labelposition=0, labelsize=10, label_visible=False): 
+    def __init__(self, arc_id=None, record=None, size=1000, interspace=3, raxis_range=(500, 550), facecolor=None, edgecolor="#303030", linewidth=0.75, label=None, labelposition=0, labelsize=10, label_visible=False):
+        """
+        
+
+        Parameters
+        ----------
+        arc_id : str, optional
+            Unique identifier for the Garc class object. In the event an id
+            value is not provided, an original unique ID is automatically 
+            generated for Garc object. The default is None.
+        record : Bio.SeqRecord class object or NCBI accession number, optional
+            Bio.SeqRecord class object or NCBI accession number of an annotated
+            sequence. If a NCBI accession number is given, the GeBank reord of 
+            the accesion number will be loaded from NCBI public database.
+            The default is None.
+        size : float, optional
+            Width of the arc section. If record is provided, the value is 
+            instead set by the sequence length of the record. In reality
+            the actual arc section width in the resultant circle is determined
+            by the ratio of size to the combined sum of the size and interspace
+            values of the Garc class objects in the Gcircle class object.
+            The default is 1000.
+        interspace : float, optional
+            Distance angle (units?) to the adjacent arc section in clockwise 
+            sequence. The actual interspace size in the circle is determined by
+            the actual arc section width in the resultant circle is determined
+            by the ratio of size to the combined sum of the size and interspace
+            values of the Garc class objects in the Gcircle class object.
+            The default is 3.
+        raxis_range : tuple (top=int, bottom=int), optional
+            Radial axis range where line plot is drawn.
+            The default is (550, 600).
+        facecolor : str or tuple representing color code, optional
+            Color for filling.. The default is None.
+        edgecolor : str or tuple representing color code, optional
+            Edge color of the filled area. The default is "#303030".
+        linewidth : float, optional
+            Edge line width. The default is 0.75.
+        label : str, optional
+            Label of the arc section. The default is None.
+        labelposition : int, optional
+            Relative label height from the center of the arc section.
+            The default is 0.
+        labelsize : int, optional
+            Font size of the label. The default is 10.
+        label_visible : bool, optional
+            If True, label of the Garc object is shown on the arc section.
+            The default is False.
+
+        Raises
+        ------
+        ValueError
+            In the event no match for the NCBI accession number value input in
+            the record input variable, an error is raised.
+
+        Returns
+        -------
+        None.
+
+        """
         self._parental_gcircle = None
         if arc_id == None:
             self.arc_id = str(Garc._arcnum) 
@@ -105,6 +164,31 @@ class Garc:
         Garc._arcnum += 1
 
     def calc_density(self, positions, window_size=1000):
+        """
+        Converts positions consisting of x-coordinates into a list of density
+        values scanned in a sliding window.
+
+        Parameters
+        ----------
+        positions : list of int or tuple
+            List of x coordinate values or tuple consisting of two x coordinate
+            values. Each coordinate value should be in the range 0 to the 
+            size of Garc object.
+        window_size : int, optional
+            Size of the sliding window. The default is 1000.
+
+        Raises
+        ------
+        ValueError
+            If an inappropriate value or values is input for positions, an
+            error is raised
+
+        Returns
+        -------
+        densities : list
+            A list consisting of density values.
+
+        """
         densities = [] 
         positions.sort()
         for i in range(0, self.size, window_size): 
@@ -118,7 +202,7 @@ class Garc:
                     if pos[0] <= source[-1] and pos[1] >= source[0]:
                         amount += 1
                 else:
-                    raise ValueError("List elements should be int type or tuple consiting of two int values")
+                    raise ValueError("List elements should be int type or tuple consisting of two int values")
             densities.append(amount) 
 
         source = tuple(range(i,self.size))
@@ -131,11 +215,39 @@ class Garc:
                 if pos[0] <= source[-1] and pos[1] >= source[0]:
                     amount += 1
             else:
-                raise ValueError("List elements should be int type or tuple consiting of two int values")
+                raise ValueError("List elements should be int type or tuple consisting of two int values")
         densities.append(amount*((self.size-i)/window_size))     
         return densities 
 
     def calc_nnratio(self, n1="G", n2="C", window_size=1000, step_size=None):
+        """
+        Calculates the ratio of n1 and n2 base frequency for multiple windows
+        along the sequence.
+
+        Parameters
+        ----------
+        n1 : string corresponding to one of "ATGC", optional
+            The first of the two nucleotide bases to be compared.
+            The default is "G".
+        n2 : string corresponding to one of "ATGC", optional
+            The second of the two nucleotide bases to be compared.
+            The default is "C".
+        window_size : int, optional
+            Size of the sliding window. The default is 1000.
+        step_size : float, optional
+            (unknown functionality). The default is window_size.
+
+        Raises
+        ------
+        ValueError
+            In the event no record is provided, will return an error.
+
+        Returns
+        -------
+        gc_amounts : np.array
+            An array of the ratios computed by this method
+
+        """
         if self.record is None:
             raise ValueError("self.record is None, please specify record value")
         
@@ -155,11 +267,39 @@ class Garc:
         else:
             gc_amounts.append((seq[i:].upper().count(n1) + seq[i:i+window_size].upper().count(n2)) * 1.0 / (len(seq)-i))
         
-        self["{}{}_ratio".foramt(n1,n2)] = gc_amounts
+        self["{}{}_ratio".format(n1,n2)] = gc_amounts
         gc_amounts = np.array(gc_amounts)
         return gc_amounts
 
     def calc_nnskew(self, n1="G", n2="C", window_size=1000, step_size=None):
+        """
+        Calculates n1,n2 skew (n1-n2)/(n1+n2) for multiple windows along
+        the sequence.
+
+        Parameters
+        ----------
+        n1 : string corresponding to one of "ATGC", optional
+            The first of the two nucleotide bases to be compared.
+            The default is "G".
+        n2 : string corresponding to one of "ATGC", optional
+            The second of the two nucleotide bases to be compared.
+            The default is "C".
+        window_size : int, optional
+            Size of the sliding window. The default is 1000.
+        step_size : float, optional
+            (unknown functionality). The default is window_size.
+
+        Raises
+        ------
+        ValueError
+            In the event no record is provided, will return an error.
+
+        Returns
+        -------
+        gc_skews : np.array
+            An array of the skews computed by this method
+
+        """
         #(G-C)/(G+C) 
         if self.record is None:
             raise ValueError("self.record is None, please specify record value")
@@ -194,9 +334,42 @@ class Gcircle:
         self.color_cycle = 0 
 
     def add_garc(self, garc):
+        """
+        Add a new Garc class object into garc_dict.
+
+        Parameters
+        ----------
+        garc : Garc class object (default:None)
+            Garc class object to be added.
+
+        Returns
+        -------
+        None.
+
+        """
         self._garc_dict[garc.arc_id] = garc
 
     def set_garcs(self, start=0, end=360):
+        """
+        Visualize the arc rectangles of the Garc class objects in .garc_dict on
+        the drawing space. After the execution of this method, a new Garc class
+        object cannot be added to garc_dict and figure parameter representing
+        maplotlib.pyplot.figure object will be created in Gcircle object.
+
+        Parameters
+        ----------
+        start : int, optional
+            Start angle of the circos plot. The value range is -360 ~ 360.
+            The default is 0.
+        end : int, optional
+            End angle of the circos plot. The value range is -360 ~ 360.
+            The default is 360.
+
+        Returns
+        -------
+        None.
+
+        """
         sum_length       = sum(list(map(lambda x:  self._garc_dict[x]["size"], list(self._garc_dict.keys()))))
         sum_interspace   = sum(list(map(lambda x:  self._garc_dict[x]["interspace"], list(self._garc_dict.keys()))))
         start = 2 * np.pi * start / 360
@@ -255,6 +428,51 @@ class Gcircle:
         self.ax.bar([pos], [height], bottom=bottom, width=width, facecolor=facecolor, linewidth=linewidth, edgecolor=edgecolor, align="edge", zorder=0)
     
     def lineplot(self, garc_id, data, positions=None, raxis_range=(550, 600), rlim=None, linestyle="solid", linecolor=None, linewidth=1.0, spine=False):
+        """
+        Plot a line in the sector corresponding to the arc of the Garc class
+        object specified by garc_id.
+
+        Parameters
+        ----------
+        garc_id : str 
+            ID of the Garc class object. The ID should be in Gcircle
+            object.garc_dict.
+        data : list or numpy.ndarray
+            Numerical data to used for plot generation.
+        positions : list or numpy.ndarray 
+            The x coordinates of the values in data on the Garc class object 
+            when the plot is drawn on the rectangular coordinates. Each
+            coordinate value should be in the range 0 to size of the Garc class
+            object specified by garc_id. By the method execution, the 
+            coordinates are converted to proper angle coordinates. If positions
+            are not given, proper coordinates values are generated according to
+            the length of data. The default is None.
+        raxis_range : tuple (top=int, bottom=int), optional
+            Radial axis range where line plot is drawn.
+            The default is (550, 600).
+        rlim : tuple (top=int, bottom=int)
+            The top and bottom r limits in data coordinates. If rlim value is
+            not given, the maximum value and the minimum value in data will be 
+            set to top and bottom, respectively. The default is None.
+        linestyle : str, optional
+            Line style. Possible line styles are documented at
+            https://matplotlib.org/stable/gallery/lines_bars_and_markers/linestyles.html.
+            The default is "solid".
+        linecolor : str or tuple representing color code, optional
+            Color of the line plot. If linecolor value is not given, the color 
+            will be set according to the default color set of matplotlib. To 
+            specify the opacity for a line color, please use (r, g, b, a) or 
+            #XXXXXXXX format. The default is None.
+        linewidth : float, optional
+            Edge line width. The default is 1.0.
+        spine : TYPE, optional
+            TBD. The default is False.
+
+        Returns
+        -------
+        None.
+
+        """
         start = self._garc_dict[garc_id].coordinates[0] 
         end   = self._garc_dict[garc_id].coordinates[-1]
         size  = self._garc_dict[garc_id].size - 1
@@ -306,6 +524,50 @@ class Gcircle:
             self.setspine(garc_id, raxis_range)
 
     def fillplot(self, garc_id, data, positions=None, raxis_range=(550, 600), rlim=None, base_value=None, facecolor=None, edgecolor="#303030", linewidth=0.0, spine=False):  
+        """
+        Fill a specified area in the sector corresponding to the arc of the 
+        Garc class object specified by garc_id.
+
+        Parameters
+        ----------
+        garc_id : str 
+            ID of the Garc class object. The ID should be in Gcircle 
+            object.garc_dict.
+        data : list or numpy.ndarray
+            Numerical data to used for plot generation.
+        positions : list or numpy.ndarray 
+            The x coordinates of the values in data on the Garc class object 
+            when the plot is drawn on the rectangular coordinates. Each
+            coordinate value should be in the range 0 to size of the Garc class
+            object specified by garc_id. By the method execution, the
+            coordinates are converted to proper angle coordinates. If positions
+            are not given, proper coordinates values are generated according to
+            the length of data.. The default is None.
+        raxis_range : tuple (top=int, bottom=int), optional
+            Radial axis range where line plot is drawn. The default is 
+            (550, 600).
+        rlim : tuple (top=int, bottom=int)
+            The top and bottom r limits in data coordinates. If rlim value is
+            not given, the maximum value and the minimum value in data will be 
+            set to top and bottom, respectively. 
+            The default is (min(data), max(data).
+        base_value : float, optional
+            Base line height in data coordinates. The area between the base 
+            line and the data line is filled by facecolor. The default is None.
+        facecolor : str or tuple representing color code, optional
+            Color for filling.. The default is None.
+        edgecolor : str or tuple representing color code, optional
+            Edge color of the filled area. The default is "#303030".
+        linewidth : float, optional
+            Edge line width. The default is 0.0.
+        spine : TYPE, optional
+            TBD. The default is False.
+
+        Returns
+        -------
+        None.
+
+        """
         start = self._garc_dict[garc_id].coordinates[0] 
         end   = self._garc_dict[garc_id].coordinates[-1]
         size  = self._garc_dict[garc_id].size - 1
@@ -360,7 +622,56 @@ class Gcircle:
         if spine == True:
             self.setspine(garc_id, raxis_range)
 
-    def scatterplot(self, garc_id, data, positions=None, raxis_range=(550, 600), rlim=None, markershape="o", markersize=5, facecolor=None, edgecolor="#303030", fadcecolors=None, linewidth=0.0, spine=False):
+    def scatterplot(self, garc_id, data, positions=None, raxis_range=(550, 600), rlim=None, markershape="o", markersize=5, facecolor=None, edgecolor="#303030", linewidth=0.0, spine=False):
+        """
+        Plot markers in the sector corresponding to the arc of the Garc class
+        object specified by garc_id.
+
+        Parameters
+        ----------
+        garc_id : str 
+            ID of the Garc class object. The ID should be in Gcircle 
+            object.garc_dict.
+        data : list or numpy.ndarray
+            Numerical data to used for plot generation.
+        positions : list or numpy.ndarray 
+            The x coordinates of the values in data on the Garc class object 
+            when the plot is drawn on the rectangular coordinates. Each
+            coordinate value should be in the range 0 to size of the Garc class
+            object specified by garc_id. By the method execution, the
+            coordinates are converted to proper angle coordinates. If positions
+            are not given, proper coordinates values are generated according to
+            the length of data.. The default is None.
+        raxis_range : tuple (top=int, bottom=int), optional
+            Radial axis range where line plot is drawn. The default is 
+            (550, 600).
+        rlim : tuple (top=int, bottom=int)
+            The top and bottom r limits in data coordinates. If rlim value is
+            not given, the maximum value and the minimum value in data will be 
+            set to top and bottom, respectively. 
+            The default is (min(data), max(data).
+        markershape : str, optional
+            Marker shape. Possible marker are listed at
+            https://matplotlib.org/stable/gallery/lines_bars_and_markers/marker_reference.html.
+            The default is "o".
+        markersize: float or list of float, optional
+            Size(s) of the marker(s). The default is 5.
+        facecolor : str or tuple representing color code or list thereof, optional
+            Face color(s) of the markers. If value type is list, the length of
+            facecolor should be the same as the data length.
+            The default is None.
+        edgecolor : str or tuple representing color code, optional
+            Edge color of the markers. The default is "#303030".
+        linewidth : float, optional
+            Edge line width of the markers. The default is 0.0.
+        spine : TYPE, optional
+            TBD. The default is False.
+
+        Returns
+        -------
+        None.
+
+        """
         start = self._garc_dict[garc_id].coordinates[0] 
         end   = self._garc_dict[garc_id].coordinates[-1]
         size  = self._garc_dict[garc_id].size - 1
@@ -413,6 +724,52 @@ class Gcircle:
             self.setspine(garc_id, raxis_range)
     
     def barplot(self, garc_id, data, positions=None, width=None, raxis_range=(550, 600), rlim=None, base_value=None, facecolor=None, edgecolor="#303030", linewidth=0.0, spine=False):  
+        """
+        Plot bars in the sector corresponding to the arc of the Garc class 
+        object specified by garc_id.
+
+        Parameters
+        ----------
+        garc_id : str 
+            ID of the Garc class object. The ID should be in Gcircle 
+            object.garc_dict.
+        data : list or numpy.ndarray
+            Numerical data to used for plot generation.
+        positions : list or numpy.ndarray 
+            The x coordinates of the values in data on the Garc class object 
+            when the plot is drawn on the rectangular coordinates. Each
+            coordinate value should be in the range 0 to size of the Garc class
+            object specified by garc_id. By the method execution, the
+            coordinates are converted to proper angle coordinates. If positions
+            are not given, proper coordinates values are generated according to
+            the length of data.. The default is None.
+        raxis_range : tuple (top=int, bottom=int), optional
+            Radial axis range where line plot is drawn.
+            The default is (550, 600).
+        rlim : tuple (top=int, bottom=int)
+            The top and bottom r limits in data coordinates. If rlim value is
+            not given, the maximum value and the minimum value in data will be 
+            set to top and bottom, respectively. 
+            The default is (min(data), max(data).
+        base_value : float, optional
+            Base line height in data coordinates. The area between the base 
+            line and the data line is filled by facecolor. The default is None.
+        facecolor : str or tuple representing color code or list thereof, optional
+            Facecolor(s) of the bars. If value type is list, the length of 
+            facecolor should be the same as the data length.
+            The default is None.
+        edgecolor : str or tuple representing color code, optional
+            Edge color of the bars. The default is "#303030".
+        linewidth : float, optional
+            Edge line width of the bars. The default is 0.0.
+        spine : TYPE, optional
+            TBD. The default is False.
+
+        Returns
+        -------
+        None.
+
+        """
         start = self._garc_dict[garc_id].coordinates[0] 
         end   = self._garc_dict[garc_id].coordinates[-1]
         size  = self._garc_dict[garc_id].size - 1
@@ -498,6 +855,50 @@ class Gcircle:
             self.setspine(garc_id, raxis_range)
     
     def heatmap(self, garc_id, data, positions=None, width=None, raxis_range=(550, 600), cmap=None, vmin=None, vmax=None, edgecolor="#303030", linewidth=0.0, spine=False):  
+        """
+        Visualize magnitudes of data values by color scale in the sector
+        corresponding to the arc of the Garc class object specified by garc_id.
+
+        Parameters
+        ----------
+        garc_id : str 
+            ID of the Garc class object. The ID should be in Gcircle 
+            object.garc_dict.
+        data : list or numpy.ndarray
+            Numerical data to used for plot generation.
+        positions : list or numpy.ndarray 
+            The x coordinates of the values in data on the Garc class object 
+            when the plot is drawn on the rectangular coordinates. Each
+            coordinate value should be in the range 0 to size of the Garc class
+            object specified by garc_id. By the method execution, the
+            coordinates are converted to proper angle coordinates. If positions
+            are not given, proper coordinates values are generated according to
+            the length of data. The default is None.
+        width : float or list of float, optional
+            Width(s) of the bars. The default is garc_object.size/len(data).
+        raxis_range : tuple (top=int, bottom=int), optional
+            Radial axis range where line plot is drawn. The default is 
+            (550, 600).
+        cmap : str representing matplotlib colormap name or
+        matplotlib.colors.Colormap object, optional
+            The mapping from data values to color space. The default is 'Reds'.
+        vmin : float, optional
+            Minimum data threshold for color scale. The default is min(data).
+        vmax : TYPE, optional
+            Maximum data threshold for color scale. The default is max(data).
+        edgecolor : str or tuple representing color code, optional
+            Edge color of the bars. The default is "#303030".
+        linewidth : float, optional
+            Edge line width of the bars. The default is 0.0.
+        spine : TYPE, optional
+            TBD. The default is False.
+
+        Returns
+        -------
+        None.
+
+        """
+        
         start = self._garc_dict[garc_id].coordinates[0] 
         end   = self._garc_dict[garc_id].coordinates[-1]
         size  = self._garc_dict[garc_id].size - 1
@@ -550,6 +951,43 @@ class Gcircle:
             self.setspine(garc_id, raxis_range)
     
     def featureplot(self, garc_id, feature_type=None, source=None, raxis_range=(550, 600), facecolor=None, edgecolor="#303030", spine=False):  
+        """
+        Visualize sequence features with bar plots in the sector corresponding
+        to the arc of the Garc class object specified by garc_id.
+
+        Parameters
+        ----------
+        garc_id : str 
+            ID of the Garc class object. The ID should be in Gcircle 
+            object.garc_dict.
+        feature_type : str, optional
+            Biological nature of the Bio.Seqfeature class objects (Any value is
+            acceptable, but GenBank format requires registering a biological 
+            nature category for each sequence feature). If the value is "all",
+            all features in source will be drawn in the sector of the Garc 
+            class object specified by grac_id. The default is 'all'.
+        source : list of Bio.SeqFeature object, optional
+            List of Bio.Seqfeature class object. If source value is not given, 
+            record.features of the Garc class object specified by grac_id is 
+            used. The default is record.features of the Garc class object
+            specified by grac_id.
+        raxis_range : tuple (top=int, bottom=int), optional
+            Radial axis range where line plot is drawn.
+            The default is (550, 600).
+        facecolor : str or tuple representing color code or list thereof, optional
+            Facecolor(s) of the bars. If value type is list, the length of 
+            facecolor should be the same as the data length.
+            The default is None.
+        edgecolor : str or tuple representing color code, optional
+            Edge color of the bars. The default is "#303030".
+        spine : TYPE, optional
+            TBD. The default is False.
+
+        Returns
+        -------
+        None.
+
+        """
         start = self._garc_dict[garc_id].coordinates[0] 
         end   = self._garc_dict[garc_id].coordinates[-1] 
         size  = self._garc_dict[garc_id].size - 1
@@ -591,6 +1029,51 @@ class Gcircle:
             self.setspine(garc_id, raxis_range)
     
     def chord_plot(self, start_list, end_list, facecolor=None, edgecolor=None, linewidth=0.0):
+        """
+        Visualize interrelationships between data.
+
+        Parameters
+        ----------
+        start_list : tuple
+            First data location of linked data. 
+            The tuple is composed of four parameters:
+                arc_id: the ID of the first Garc class object to be compared.
+                    The ID should be in Gcircle object.garc_dict.
+                object.garc_dict.
+                edge_position1: the minimal x coordinates on the Garc class 
+                    object when the plot is drawn on the rectangular
+                    coordinates.
+                edge_position2: the maximal x coordinates on the Garc class 
+                    object when the plot is drawn on the rectangular
+                    coordinates.
+                raxis_position: the base height for the drawing cord.
+        end_list : tuple
+            First data location of linked data. 
+            The tuple is composed of four parameters:
+                arc_id: the ID of the second Garc class object to be compared.
+                    The ID should be in Gcircle object.garc_dict. 
+                object.garc_dict.
+                edge_position1: the minimal x coordinates on the Garc class 
+                    object when the plot is drawn on the rectangular
+                    coordinates.
+                edge_position2: the maximal x coordinates on the Garc class 
+                    object when the plot is drawn on the rectangular
+                    coordinates.
+                raxis_position: the base height for the drawing cord.
+         facecolor : str or tuple representing color code or list thereof, optional
+             Facecolor(s) of the bars. If value type is list, the length of 
+             facecolor should be the same as the data length.
+             The default is None.
+        edgecolor : str or tuple representing color code, optional
+            Edge color of the bars. The default is "#303030".
+        linewidth : float, optional
+            Edge line width of the bars. The default is 0.0.
+
+        Returns
+        -------
+        None.
+
+        """
         garc_id1 = start_list[0]
         garc_id2 = end_list[0]
         center = 0 


### PR DESCRIPTION
Made a few changes mostly to the docstrings, copying from the readme.
In a couple cases, where it seemed there may have been code issues issues, changes were made.  Please check after me to make sure the changes are sensible/correct.:

Locations of non-docstring changes

- [removed input variable "fadcecolors" from inputs of scatterplot](https://github.com/ponnhide/pyCircos/blob/ef76d077dd3b1802ed99704d4dad384d4c6cb730/pycircos/pycircos.py#L363).  "fadcecolors" not referenced in scatterplot function, and seemed to duplicate purpose of "facecolor".
- [changed "foramt" call to "format"](https://github.com/ponnhide/pyCircos/blob/ef76d077dd3b1802ed99704d4dad384d4c6cb730/pycircos/pycircos.py#L158).  I think the goal was to format the input, I'm not familiar with a "foramt" functionality, could be wrong about this though.

Also, my IDE is telling me that a few values/variables are undefined (but it could be mistaken in highlighting these sections):

-["value"](https://github.com/ponnhide/pyCircos/blob/ef76d077dd3b1802ed99704d4dad384d4c6cb730/pycircos/pycircos.py#L62)
-["ticks"](https://github.com/ponnhide/pyCircos/blob/ef76d077dd3b1802ed99704d4dad384d4c6cb730/pycircos/pycircos.py#L642)
-["bottom"](https://github.com/ponnhide/pyCircos/blob/ef76d077dd3b1802ed99704d4dad384d4c6cb730/pycircos/pycircos.py#L644-L646)
-["color"](https://github.com/ponnhide/pyCircos/blob/ef76d077dd3b1802ed99704d4dad384d4c6cb730/pycircos/pycircos.py#L644-L646)

