### PR TITLE
Fix API Documents workflow

### DIFF
--- a/.github/workflows/publish_api_docs.yml
+++ b/.github/workflows/publish_api_docs.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/pycircos


### PR DESCRIPTION
There was a small error in the workflow for PR (#17).
It looks like the documentation generation to the `gh-pages` branch is failing because of it.

Sorry for the trouble. Please merge the corrected version.