### PR TITLE
size for chord plot

### DIFF
--- a/pycircos/pycircos.py
+++ b/pycircos/pycircos.py
@@ -1112,14 +1112,14 @@ class Gcircle:
 
         start1 = self._garc_dict[garc_id1].coordinates[0] 
         end1   = self._garc_dict[garc_id1].coordinates[-1] 
-        size1  = self._garc_dict[garc_id1].size - 1
+        size1  = self._garc_dict[garc_id1].size
         sstart = start1 + ((end1-start1) * start_list[1]/size1) 
         send   = start1 + ((end1-start1) * start_list[2]/size1)
         stop   = start_list[3] 
         
         start2 = self._garc_dict[garc_id2].coordinates[0] 
         end2   = self._garc_dict[garc_id2].coordinates[-1] 
-        size2  = self._garc_dict[garc_id2].size - 1
+        size2  = self._garc_dict[garc_id2].size
         ostart = start2 + ((end2-start2) * end_list[1]/size2) 
         oend   = start2 + ((end2-start2) * end_list[2]/size2)
         etop   = end_list[3] 


### PR DESCRIPTION
Chord plot size was too small by 1, so chords become more and more offset as one moves around an arc. Not subtracting 1 from the size seems to fix it. The offset is visible in the final plot of the first tutorial.